### PR TITLE
Updates to use pre-built Blockscout docker image

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -8,40 +8,34 @@ services:
     container_name: redis_db
     command: redis-server
     volumes:
-      - ./redis-data:/data
+      - redis-data:/data
 
   db:
     image: postgres:14
+    command: -c shared_buffers=1024MB -c max_connections=200
     restart: always
     container_name: 'postgres'
+    healthcheck:
+      test: [ "CMD", "pg_isready"]
+      timeout: 45s
+      interval: 10s
+      retries: 10
     environment:
-        POSTGRES_PASSWORD: ''
+        POSTGRES_PASSWORD: 'password'
         POSTGRES_USER: 'postgres'
         POSTGRES_HOST_AUTH_METHOD: 'trust'
+    # Uncomment the following line to persist the database 
+    # Dont forget the volume in the bottom of the file as well
+    # volumes:
+    #   - postgres-data:/var/lib/postgresql/data
     ports:
-      - 7432:5432
+      - 5432
 
   blockscout:
     depends_on:
-      - db
-      - smart-contract-verifier
-      - redis_db
-    image: blockscout/blockscout:${DOCKER_TAG:-latest}
-    build:
-      context: ..
-      dockerfile: ./docker/Dockerfile
-      args:
-        CACHE_EXCHANGE_RATES_PERIOD: ""
-        DISABLE_READ_API: "false"
-        API_PATH: "/"
-        NETWORK_PATH: "/"
-        DISABLE_WEBAPP: "false"
-        DISABLE_WRITE_API: "false"
-        CACHE_ENABLE_TOTAL_GAS_USAGE_COUNTER: ""
-        CACHE_ADDRESS_WITH_BALANCES_UPDATE_INTERVAL: ""
-        SOCKET_ROOT: "/"
-        WOBSERVER_ENABLED: "false"
-        ADMIN_PANEL_ENABLED: ""
+      db:
+        condition: service_healthy  
+    image: blockscout/blockscout:latest
     restart: always
     container_name: 'blockscout'
     links:
@@ -49,8 +43,24 @@ services:
     command: bash -c "bin/blockscout eval \"Elixir.Explorer.ReleaseTasks.create_and_migrate()\" && bin/blockscout start"
     extra_hosts:
       - 'host.docker.internal:host-gateway'
-    env_file:
-      -  ./envs/common-blockscout.env
+    environment:
+        ETHEREUM_JSONRPC_VARIANT: 'geth'
+        BLOCK_TRANSFORMER: 'base'
+        ETHEREUM_JSONRPC_HTTP_URL: http://165.227.210.22:8545/
+        DATABASE_URL: postgresql://postgres:password@db:5432/blockscout?ssl=false
+        ECTO_USE_SSL: 'false'
+        SECRET_KEY_BASE: '56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN'
+        NETWORK: Eth1
+        SUBNETWORK: EthOne
+        COIN: EthOne
+        # ETHEREUM_JSONRPC_TRACE_URL: http://165.227.210.22:8545/
+        ETHEREUM_JSONRPC_WS_URL: ws://165.227.210.22:8545/
+        CHECKSUM_FUNCTION: eth
+        APPS_MENU: false
+        CHAIN_ID: 4949
+        JSON_RPC: http://165.227.210.22:8545/
+        RUST_VERIFICATION_SERVICE_URL: http://smart-contract-verifier:8043/
+        PORT: 4000
     ports:
       - 4000:4000
 
@@ -62,3 +72,8 @@ services:
       -  ./envs/common-smart-contract-verifier.env
     ports:
       - 8043:8043
+
+volumes:
+   redis-data:
+  # uncomment the following line to persist the database
+  #  postgres-data:


### PR DESCRIPTION
TODO:// Replace the blockscout image with an Eth1 image (or at least use a tagged release) 